### PR TITLE
feat: Add support to disable root-check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 changelog
 *************************
+2.x.y - Date
+..........................................................
+* Support command line flag to allow pg_chameleon to run as root
+
 2.0.16 - 23 September 2020
 ..........................................................
 * Fix for issue #126 init_replica failure with tables on transactional engine and invalid data

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,7 +6,7 @@ Command line reference
 
 .. code-block:: bash
 
-    chameleon command [ [ --config ] [ --source ] [ --schema ]  [ --tables ] [--logid] [ --debug ] [ --rollbar-level ] ] [ --version ] [ --full ]
+    chameleon command [ [ --config ] [ --source ] [ --schema ]  [ --tables ] [--logid] [ --debug ] [ --rollbar-level ] ] [ --version ] [ --full ] [ --allow-root ]
 
 .. csv-table:: Options
    :header: "Option", "Description", "Default","Example"
@@ -20,6 +20,7 @@ Command line reference
    ``--version``,Displays the package version., N/A, ``--version``
    ``--rollbar-level``, Sets the maximum level for the messages to be sent  to rolllbar. Accepted values: "critical" "error" "warning" "info", ``info`` ,``--rollbar-level error``
    ``--full``,Runs a VACUUM FULL  on the log tables when the run_maintenance is executed, N/A,``--full``
+   ``--allow-root``,Allow pg_chameleon to be run as root user, N/A,``--allow-root``
 
 
 .. csv-table:: Command list reference

--- a/pg_chameleon/lib/global_lib.py
+++ b/pg_chameleon/lib/global_lib.py
@@ -68,8 +68,8 @@ class replica_engine(object):
         """
             Class constructor.
         """
-        if os.geteuid()==0:
-            print ("pg_chameleon cannot be run as root")
+        if os.geteuid()==0 and not args.allow_root :
+            print ("pg_chameleon cannot be run as root, supply the `--allow-root` flag to disable this check.")
             sys.exit(10)
 
 

--- a/scripts/chameleon.py
+++ b/scripts/chameleon.py
@@ -38,6 +38,7 @@ version_help = """Displays pg_chameleon's installed  version."""
 rollbar_help = """Overrides the level for messages to be sent to rolllbar. One of: "critical", "error", "warning", "info". The Default is "info" """
 full_help = """When specified with run_maintenance the switch performs a vacuum full instead of a normal vacuum. """
 truncate_help = """Truncate the existing tables instead of replacing them."""
+allow_root_help = """Allows pg_chameleon to be run as root user"""
 
 parser = argparse.ArgumentParser(description='Command line for pg_chameleon.',  add_help=True)
 parser.add_argument('command', type=str, help=command_help)
@@ -50,6 +51,7 @@ parser.add_argument('--debug', default=False, required=False, help=debug_help, a
 parser.add_argument('--version', action='version', help=version_help,version='{version}'.format(version=__version__))
 parser.add_argument('--rollbar-level', type=str, default="info", required=False, help=rollbar_help)
 parser.add_argument('--full', default=False, required=False, help=full_help, action='store_true')
+parser.add_argument('--allow-root', default=False, required=False, help=allow_root_help, action='store_true')
 args = parser.parse_args()
 
 


### PR DESCRIPTION
This change adds the `--allow-root` flag as a command-line argument. If supplied it will let `pg_chameleon` run as root. This is especially useful in Docker scenarios.

The default is still that `pg_chameleon` will throw an error and exit if being run as `root`.